### PR TITLE
Better support for Array, add Hash support and some support for EXPRESSION_GET_ATTR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `EXPRESSION_CONSTANT`        | `"foo"`, `123`                                                                | :heavy_check_mark: |
 | `EXPRESSION_FILTER`          | ...                                                                           | :x: |
 | `EXPRESSION_FUNCTION`        | ...                                                                           | :x: |
-| `EXPRESSION_GET_ATTR`        | ...                                                                           | :x: |
+| `EXPRESSION_GET_ATTR`        | Accessing an attribute, e.g.: `foo.bar`                                       | :x: |
 | `EXPRESSION_METHOD_CALL`     | ...                                                                           | :x: |
 | `EXPRESSION_NAME`            | Usage of a variable                                                           | :heavy_check_mark: |
 | `EXPRESSION_NULL_COALESCE`   | ...                                                                           | :x: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `BLOCK`                      | `{% block title%}The title{% endblock %}`                                     | :x: |
 | `DEPRECATED`                 | `{% deprecated 'The "base.twig" template is deprecated' %}`                   | :x: |
 | `DO`                         | `{% do 1 + 2 %}`                                                              | :x: |
-| `EXPRESSION_ARRAY`           | `[1, 'foo', 3]`                                                               | :heavy_check_mark: |
+| `EXPRESSION_ARRAY`           | `[1, 'foo', 3]`, `{ a: 'a': b: 'b' }`                                         | :heavy_check_mark: |
 | `EXPRESSION_ASSIGN_NAME`     | ...                                                                           | :x: |
 | `EXPRESSION_BINARY`          | ...                                                                           | :x: |
 | `EXPRESSION_BINARY_RANGE`    | ...                                                                           | :x: |
@@ -27,7 +27,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `EXPRESSION_FUNCTION`        | ...                                                                           | :x: |
 | `EXPRESSION_GET_ATTR`        | ...                                                                           | :x: |
 | `EXPRESSION_METHOD_CALL`     | ...                                                                           | :x: |
-| `EXPRESSION_NAME`            | ...                                                                           | :x: |
+| `EXPRESSION_NAME`            | Usage of a variable                                                           | :heavy_check_mark: |
 | `EXPRESSION_NULL_COALESCE`   | ...                                                                           | :x: |
 | `EXPRESSION_PARENT`          | ...                                                                           | :x: |
 | `EXPRESSION_TEST`            | ...                                                                           | :x: |

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,4 +1,4 @@
-const { TwingNode, TwingNodeType, TwingNodeExpressionHash } = require("twing");
+const { TwingNode, TwingNodeType, TwingNodeExpressionHash, TwingNodeExpressionName } = require("twing");
 const { indent, join, line, softline, hardline, concat, group, ifBreak } = require("prettier").doc.builders;
 const util = require("./_util-from-prettier");
 
@@ -106,6 +106,8 @@ function genericPrint(path, options, print) {
     }
     case TwingNodeType.EXPRESSION_ARRAY: {
       const isHash = node instanceof TwingNodeExpressionHash;
+      const openDoc = isHash ? concat(["{", ifBreak(" ", line)]) : "[";
+      const closeDoc = isHash ? concat([ifBreak("", line), "}"]) : "]";
 
       const items = [];
       for (let i = 0; i < node.getNodes().size; i += 2) {
@@ -113,7 +115,7 @@ function genericPrint(path, options, print) {
         const valueNode = node.getNode(i + 1);
 
         if (isHash) {
-          const keyName = keyNode.hasAttribute("name")
+          const keyName = keyNode instanceof TwingNodeExpressionName
             ? concat(["(", keyNode.getAttribute("name"), ")"])
             : keyNode.getAttribute("value");
 
@@ -130,13 +132,13 @@ function genericPrint(path, options, print) {
       }
 
       return groupConcat([
-        isHash ? concat(["{", ifBreak(" ", line)]) : "[",
+        openDoc,
         indentConcat([
           softline,
           join(concat([",", line]), items)
         ]),
         softline,
-        isHash ? concat([ifBreak("", line), "}"]) : "]"
+        closeDoc
       ]);
     }
     case TwingNodeType.EXPRESSION_CONSTANT: {

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,5 +1,5 @@
 const { TwingNode, TwingNodeType, TwingNodeExpressionHash } = require("twing");
-const { indent, join, line, softline, hardline, concat, group } = require("prettier").doc.builders;
+const { indent, join, line, softline, hardline, concat, group, ifBreak } = require("prettier").doc.builders;
 const util = require("./_util-from-prettier");
 
 // The root, in fact that's not really a node, but it contains references to blocks, macros, ...
@@ -130,13 +130,13 @@ function genericPrint(path, options, print) {
       }
 
       return groupConcat([
-        isHash ? concat(["{", line]) : "[",
+        isHash ? concat(["{", ifBreak(" ", line)]) : "[",
         indentConcat([
           softline,
           join(concat([",", line]), items)
         ]),
         softline,
-        isHash ? concat([line, "}"]) : "]"
+        isHash ? concat([ifBreak(" ", line), "}"]) : "]"
       ]);
     }
     case TwingNodeType.EXPRESSION_CONSTANT: {

--- a/src/printer.js
+++ b/src/printer.js
@@ -136,7 +136,7 @@ function genericPrint(path, options, print) {
           join(concat([",", line]), items)
         ]),
         softline,
-        isHash ? concat([ifBreak(" ", line), "}"]) : "]"
+        isHash ? concat([ifBreak("", line), "}"]) : "]"
       ]);
     }
     case TwingNodeType.EXPRESSION_CONSTANT: {

--- a/src/printer.js
+++ b/src/printer.js
@@ -44,11 +44,19 @@ function printString(rawContent, options) {
  * @return {string}
  */
 function genericPrint(path, options, print) {
-  /** @type TwingNode */
-  let node = path instanceof TwingNode ? path : path.getValue();
+  /** @type {TwingNode|string} */
+  let node = path.constructor.name === "FastPath" ? path.getValue() : path;
 
   if (!node) {
     return "";
+  }
+
+  if (typeof node === "number") {
+    return String(node);
+  }
+
+  if (typeof node === "string") {
+    return printString(node, options);
   }
 
   if (node.getType() === TwingNodeType.MODULE) {
@@ -104,6 +112,8 @@ function genericPrint(path, options, print) {
 
       return concat(["[", join(", ", values), "]"]);
     }
+    case TwingNodeType.TEXT:
+      return node.getAttribute("data");
     default:
       throw new Error(`Impossible to prettify a node of type "${node.getType()}". Please open an issue on https://github.com/Kocal/prettier-plugin-twig.`);
   }

--- a/tests/array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`array.twig 1`] = `
+Object {
+  Symbol(jest-snapshot-serializer-raw): "====================================options=====================================
+parsers: [\\"twig\\"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{% set foo = [1, 2, 3] %}
+{% set foo = [ 1,   2,   3  ] %}
+{% set foo = [ 'an', 'array',
+    'of', 'string'   ] %}
+
+{%  set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray']   %}
+
+{% set foo = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+] %}
+
+{% set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue'] %}
+
+{% set foo = [1,2,3,\\"string\\",\\"bar\\",{foo:'bar'} ] %}
+
+=====================================output=====================================
+{% set foo = [1, 2, 3] %}
+{% set foo = [1, 2, 3] %}
+{% set foo = [\\"an\\", \\"array\\", \\"of\\", \\"string\\"] %}
+
+{% set foo = [
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\"
+] %}
+
+{% set foo = [\\"a\\", \\"b\\", \\"c\\", \\"d\\", \\"e\\", \\"f\\", \\"g\\"] %}
+
+{% set foo = [
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue\\"
+] %}
+
+{% set foo = [1, 2, 3, \\"string\\", \\"bar\\", { foo: \\"bar\\" }] %}
+
+================================================================================",
+}
+`;
+
+exports[`array.twig 2`] = `
+Object {
+  Symbol(jest-snapshot-serializer-raw): "====================================options=====================================
+parsers: [\\"twig\\"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{% set foo = [1, 2, 3] %}
+{% set foo = [ 1,   2,   3  ] %}
+{% set foo = [ 'an', 'array',
+    'of', 'string'   ] %}
+
+{%  set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray']   %}
+
+{% set foo = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+] %}
+
+{% set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue'] %}
+
+{% set foo = [1,2,3,\\"string\\",\\"bar\\",{foo:'bar'} ] %}
+
+=====================================output=====================================
+{% set foo = [1, 2, 3] %}
+{% set foo = [1, 2, 3] %}
+{% set foo = [\\"an\\", \\"array\\", \\"of\\", \\"string\\"] %}
+
+{% set foo = [
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\",
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray\\"
+] %}
+
+{% set foo = [\\"a\\", \\"b\\", \\"c\\", \\"d\\", \\"e\\", \\"f\\", \\"g\\"] %}
+
+{% set foo = [
+    \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue\\"
+] %}
+
+{% set foo = [1, 2, 3, \\"string\\", \\"bar\\", { foo: \\"bar\\" }] %}
+
+================================================================================",
+}
+`;

--- a/tests/array/array.twig
+++ b/tests/array/array.twig
@@ -1,0 +1,20 @@
+{% set foo = [1, 2, 3] %}
+{% set foo = [ 1,   2,   3  ] %}
+{% set foo = [ 'an', 'array',
+    'of', 'string'   ] %}
+
+{%  set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray', 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongArray']   %}
+
+{% set foo = [
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+    'g',
+] %}
+
+{% set foo = ['aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue'] %}
+
+{% set foo = [1,2,3,"string","bar",{foo:'bar'} ] %}

--- a/tests/array/jsfmt.spec.js
+++ b/tests/array/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["twig"]);
+run_spec(__dirname, ["twig"], { printWidth: 80 });

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,7 @@ printWidth: 80
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {'a': 'a', \\"b\\":\\"b\\" } %}
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
 
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
@@ -22,6 +23,7 @@ printWidth: 80
 {% set foo = { foo: bar } %}
 {% set foo = { (foo): \\"bar\\" } %}
 {% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+{% set foo = { a: \\"a\\", b: \\"b\\" } %}
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"
@@ -52,6 +54,7 @@ printWidth: 80
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {'a': 'a', \\"b\\":\\"b\\" } %}
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
 
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
@@ -63,6 +66,7 @@ printWidth: 80
 {% set foo = { foo: bar } %}
 {% set foo = { (foo): \\"bar\\" } %}
 {% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+{% set foo = { a: \\"a\\", b: \\"b\\" } %}
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`array_hash.twig 1`] = `
+Object {
+  Symbol(jest-snapshot-serializer-raw): "====================================options=====================================
+parsers: [\\"twig\\"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{% set foo = { foo: 'bar' } %}
+{% set foo = {foo:bar}   -%}
+{% set foo = {(foo): 'bar'} %}
+{% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+
+=====================================output=====================================
+{% set foo = { foo: \\"bar\\" } %}
+{% set foo = { foo: bar } %}
+{% set foo = { (foo): \\"bar\\" } %}
+{% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+
+================================================================================",
+}
+`;
+
+exports[`array_hash.twig 2`] = `
+Object {
+  Symbol(jest-snapshot-serializer-raw): "====================================options=====================================
+parsers: [\\"twig\\"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{% set foo = { foo: 'bar' } %}
+{% set foo = {foo:bar}   -%}
+{% set foo = {(foo): 'bar'} %}
+{% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+
+=====================================output=====================================
+{% set foo = { foo: \\"bar\\" } %}
+{% set foo = { foo: bar } %}
+{% set foo = { (foo): \\"bar\\" } %}
+{% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+
+================================================================================",
+}
+`;

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -11,12 +11,31 @@ printWidth: 80
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
+
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
+}} %}
 
 =====================================output=====================================
 {% set foo = { foo: \\"bar\\" } %}
 {% set foo = { foo: bar } %}
 {% set foo = { (foo): \\"bar\\" } %}
 {% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+{% set foo = {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"
+ } %}
+
+{% set foo = {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
+        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue3\\",
+        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {
+            aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5: \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5\\"
+         }
+     }
+ } %}
 
 ================================================================================",
 }
@@ -33,12 +52,31 @@ printWidth: 80
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
+
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
+}} %}
 
 =====================================output=====================================
 {% set foo = { foo: \\"bar\\" } %}
 {% set foo = { foo: bar } %}
 {% set foo = { (foo): \\"bar\\" } %}
 {% set foo = { foo: \\"bar\\", (foo): \\"bar\\", items: { a: \\"a\\", b: \\"b\\" } } %}
+{% set foo = {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"
+ } %}
+
+{% set foo = {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
+        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue3\\",
+        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {
+            aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5: \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5\\"
+         }
+     }
+ } %}
 
 ================================================================================",
 }

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -20,7 +20,11 @@ printWidth: 80
 
 {% set page = { foo: 'Foo',
     bar: 'Bar',
-    foobar: 'foobar'
+    foobar: 'foobar',
+    foo    :  foo.foo,
+    bar: foo.foo .bar,
+    bar: foo[ foo   ].bar,
+    bar: foo [foo]  [foo].bar.bar ,
 }
 %}
 
@@ -45,7 +49,15 @@ printWidth: 80
     }
 } %}
 
-{% set page = { foo: \\"Foo\\", bar: \\"Bar\\", foobar: \\"foobar\\" } %}
+{% set page = {
+    foo: \\"Foo\\",
+    bar: \\"Bar\\",
+    foobar: \\"foobar\\",
+    foo: foo.foo,
+    bar: foo.foo.bar,
+    bar: foo[foo].bar,
+    bar: foo[foo][foo].bar.bar
+} %}
 
 ================================================================================",
 }
@@ -71,7 +83,11 @@ printWidth: 80
 
 {% set page = { foo: 'Foo',
     bar: 'Bar',
-    foobar: 'foobar'
+    foobar: 'foobar',
+    foo    :  foo.foo,
+    bar: foo.foo .bar,
+    bar: foo[ foo   ].bar,
+    bar: foo [foo]  [foo].bar.bar ,
 }
 %}
 
@@ -96,7 +112,15 @@ printWidth: 80
     }
 } %}
 
-{% set page = { foo: \\"Foo\\", bar: \\"Bar\\", foobar: \\"foobar\\" } %}
+{% set page = {
+    foo: \\"Foo\\",
+    bar: \\"Bar\\",
+    foobar: \\"foobar\\",
+    foo: foo.foo,
+    bar: foo.foo.bar,
+    bar: foo[foo].bar,
+    bar: foo[foo][foo].bar.bar
+} %}
 
 ================================================================================",
 }

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,12 @@ printWidth: 80
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
 }} %}
 
+{% set page = { foo: 'Foo',
+    bar: 'Bar',
+    foobar: 'foobar'
+}
+%}
+
 =====================================output=====================================
 {% set foo = { foo: \\"bar\\" } %}
 {% set foo = { foo: bar } %}
@@ -38,6 +44,8 @@ printWidth: 80
         }
     }
 } %}
+
+{% set page = { foo: \\"Foo\\", bar: \\"Bar\\", foobar: \\"foobar\\" } %}
 
 ================================================================================",
 }
@@ -61,6 +69,12 @@ printWidth: 80
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
 }} %}
 
+{% set page = { foo: 'Foo',
+    bar: 'Bar',
+    foobar: 'foobar'
+}
+%}
+
 =====================================output=====================================
 {% set foo = { foo: \\"bar\\" } %}
 {% set foo = { foo: bar } %}
@@ -81,6 +95,8 @@ printWidth: 80
         }
     }
 } %}
+
+{% set page = { foo: \\"Foo\\", bar: \\"Bar\\", foobar: \\"foobar\\" } %}
 
 ================================================================================",
 }

--- a/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/array_hash/__snapshots__/jsfmt.spec.js.snap
@@ -25,7 +25,7 @@ printWidth: 80
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"
- } %}
+} %}
 
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
@@ -33,9 +33,9 @@ printWidth: 80
         aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue3\\",
         aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {
             aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5: \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5\\"
-         }
-     }
- } %}
+        }
+    }
+} %}
 
 ================================================================================",
 }
@@ -66,7 +66,7 @@ printWidth: 80
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue2\\"
- } %}
+} %}
 
 {% set foo = {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue\\",
@@ -74,9 +74,9 @@ printWidth: 80
         aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: \\"aVeryVeryVeryVeryVeryVeryVeryLongValue3\\",
         aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {
             aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5: \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5\\"
-         }
-     }
- } %}
+        }
+    }
+} %}
 
 ================================================================================",
 }

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -3,3 +3,7 @@
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
+
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
+    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
+}} %}

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -11,6 +11,10 @@
 
 {% set page = { foo: 'Foo',
     bar: 'Bar',
-    foobar: 'foobar'
+    foobar: 'foobar',
+    foo    :  foo.foo,
+    bar: foo.foo .bar,
+    bar: foo[ foo   ].bar,
+    bar: foo [foo]  [foo].bar.bar ,
 }
 %}

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -2,3 +2,4 @@
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -8,3 +8,9 @@
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
     aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
 }} %}
+
+{% set page = { foo: 'Foo',
+    bar: 'Bar',
+    foobar: 'foobar'
+}
+%}

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -2,6 +2,7 @@
 {% set foo = {foo:bar}   -%}
 {% set foo = {(foo): 'bar'} %}
 {% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
+{% set foo = {'a': 'a', "b":"b" } %}
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}
 
 {% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {

--- a/tests/array_hash/array_hash.twig
+++ b/tests/array_hash/array_hash.twig
@@ -1,0 +1,4 @@
+{% set foo = { foo: 'bar' } %}
+{% set foo = {foo:bar}   -%}
+{% set foo = {(foo): 'bar'} %}
+{% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}

--- a/tests/array_hash/jsfmt.spec.js
+++ b/tests/array_hash/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["twig"]);
+run_spec(__dirname, ["twig"], { printWidth: 80 });


### PR DESCRIPTION
### Hashes

**Input:**
```twig
{% set foo = { foo: 'bar' } %}
{% set foo = {foo:bar}   -%}
{% set foo = {(foo): 'bar'} %}
{% set foo = {foo:'bar', (foo): 'bar', items: {a: 'a'  , b:'b'} } %}
{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: 'aVeryVeryVeryVeryVeryVeryVeryLongValue2', } %}

{% set foo = {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: 'aVeryVeryVeryVeryVeryVeryVeryLongValue', aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: 'aVeryVeryVeryVeryVeryVeryVeryLongValue3',aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5:'aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5'}
}} %}

```

**Output:**
```twig
{% set foo = { foo: "bar" } %}
{% set foo = { foo: bar } %}
{% set foo = { (foo): "bar" } %}
{% set foo = { foo: "bar", (foo): "bar", items: { a: "a", b: "b" } } %}
{% set foo = {
    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: "aVeryVeryVeryVeryVeryVeryVeryLongValue",
    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: "aVeryVeryVeryVeryVeryVeryVeryLongValue2"
} %}

{% set foo = {
    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: "aVeryVeryVeryVeryVeryVeryVeryLongValue",
    aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey2: {
        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey3: "aVeryVeryVeryVeryVeryVeryVeryLongValue3",
        aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey4: {
            aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey5: "aVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue5"
        }
    }
} %}
```