### PR TITLE
feat: begin support for print

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `INCLUDE`                    | `{% include 'user.html' %}`                                                   | :x: |
 | `MACRO`                      | `{% macro input(name, value, type = "text", size = 20) %} ... {% endmacro %}` | :x: |
 | `SANDBOX`                    | `{% sandbox %} {% include 'user.html' %} {% endsandbox %}`                    | :x: |
-| `PRINT`                      | `{{ 'foo }} `                                                                 | :heavy_check_mark: |
+| `PRINT`                      | `{{ 'foo }} `                                                                 | :heavy_check_mark: (waiting for `{{-` and `-}}`) |
 | `SET`                        | `{% set a = 'a' %} {% set a, b, = 'a', 'b' %}`                                | :heavy_check_mark: |
 | `SPACELESS`                  | `{% spaceless %}<div>  <span>Hello</span>  </div>{% endspaceless %}`          | :x: |
 | `TEXT`                       | `"some text"`                                                                 | :x: |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `INCLUDE`                    | `{% include 'user.html' %}`                                                   | :x: |
 | `MACRO`                      | `{% macro input(name, value, type = "text", size = 20) %} ... {% endmacro %}` | :x: |
 | `SANDBOX`                    | `{% sandbox %} {% include 'user.html' %} {% endsandbox %}`                    | :x: |
-| `PRINT`                      | `{{ 'foo }} `                                                                 | :heavy_check_mark: (waiting for `{{-` and `-}}`) |
+| `PRINT`                      | `{{ 'foo' }} `                                                                 | :heavy_check_mark: (waiting for `{{-` and `-}}`) |
 | `SET`                        | `{% set a = 'a' %} {% set a, b, = 'a', 'b' %}`                                | :heavy_check_mark: |
 | `SPACELESS`                  | `{% spaceless %}<div>  <span>Hello</span>  </div>{% endspaceless %}`          | :x: |
 | `TEXT`                       | `"some text"`                                                                 | :x: |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The plugin is still under development, nothing will work if you try to install i
 | `INCLUDE`                    | `{% include 'user.html' %}`                                                   | :x: |
 | `MACRO`                      | `{% macro input(name, value, type = "text", size = 20) %} ... {% endmacro %}` | :x: |
 | `SANDBOX`                    | `{% sandbox %} {% include 'user.html' %} {% endsandbox %}`                    | :x: |
+| `PRINT`                      | `{{ 'foo }} `                                                                 | :heavy_check_mark: |
 | `SET`                        | `{% set a = 'a' %} {% set a, b, = 'a', 'b' %}`                                | :heavy_check_mark: |
 | `SPACELESS`                  | `{% spaceless %}<div>  <span>Hello</span>  </div>{% endspaceless %}`          | :x: |
 | `TEXT`                       | `"some text"`                                                                 | :x: |

--- a/src/printer.js
+++ b/src/printer.js
@@ -103,6 +103,15 @@ function trimQuotes(stringValue) {
 }
 
 /**
+ * @param {TwingNode} node
+ */
+function printEveryNodes(node) {
+  return concat(
+    [...node.getNodes().values()].map(n => genericPrint(n))
+  );
+}
+
+/**
  * @param {FastPath|TwingNode} path
  * @param {Object?} opts
  * @return {string}
@@ -132,9 +141,7 @@ function genericPrint(path, opts) {
   switch (node.getType()) {
     case null:
     case TwingNodeType.BODY: {
-      return concat(
-        Array.from(node.getNodes().values()).map(n => genericPrint(n))
-      );
+      return printEveryNodes(node);
     }
     case TwingNodeType.SET: {
       const names = Array.from(
@@ -150,6 +157,7 @@ function genericPrint(path, opts) {
           .getNodes()
           .values()
       ).map(n => genericPrint(n));
+      // const values = printEveryNodes(node.getNode("values"));
 
       return join(" ", [
         "{%",
@@ -199,6 +207,13 @@ function genericPrint(path, opts) {
     }
     case TwingNodeType.EXPRESSION_NAME: {
       return node.getAttribute("name");
+    }
+    case TwingNodeType.PRINT: {
+      return join(" ", [
+        "{{",
+        printEveryNodes(node),
+        "}}"
+      ]);
     }
     case TwingNodeType.TEXT:
       return node.getAttribute("data");

--- a/tests/print/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/print/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`print.twig 1`] = `
+Object {
+  Symbol(jest-snapshot-serializer-raw): "====================================options=====================================
+parsers: [\\"twig\\"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{'foo'}}
+{{   'bar'    }}
+{{   \\"bar2\\" }}
+{{ 'bar3' }}
+
+{{ 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' }}
+
+foo {{- \\"bar\\" -}} foo
+
+=====================================output=====================================
+{{ \\"foo\\" }}
+{{ \\"bar\\" }}
+{{ \\"bar2\\" }}
+{{ \\"bar3\\" }}
+
+{{ \\"aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString\\" }}
+
+foo{{ \\"bar\\" }}foo
+
+================================================================================",
+}
+`;

--- a/tests/print/jsfmt.spec.js
+++ b/tests/print/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["twig"]);

--- a/tests/print/print.twig
+++ b/tests/print/print.twig
@@ -1,0 +1,8 @@
+{{'foo'}}
+{{   'bar'    }}
+{{   "bar2" }}
+{{ 'bar3' }}
+
+{{ 'aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString' }}
+
+foo {{- "bar" -}} foo


### PR DESCRIPTION
Actually `{{-` and `-}}` are not supported because of https://github.com/ericmorand/twing/issues/321#issuecomment-476987422