### PR TITLE
WIP chore: drop twing for twig-lexer

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -18,13 +18,12 @@ export default {
     exports: "named",
     globals: {
       prettier: "prettier",
-      twing: "Twing"
     },
     paths: {
       prettier: "prettier/standalone"
     }
   },
-  external: ["prettier", "twing"],
+  external: ["prettier"],
   plugins: [
     nodeResolve(),
     commonjs(),

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,11 @@ const ENABLE_COVERAGE = !!process.env.CI;
 
 const makeBaseProject = () => ({
   setupFiles: ["<rootDir>/tests_config/run_spec.js"],
-  testRegex: "jsfmt\\.spec\\.js$|__tests__/.*\\.js$",
-  snapshotSerializers: ["jest-snapshot-serializer-raw"]
+  testRegex: "jsfmt\.spec\.js$|unit/(.+)\.js$",
+  snapshotSerializers: ["jest-snapshot-serializer-raw"],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 });
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "linguist-languages": "^6.3.0",
-    "twing": "^2.2.2"
+    "twig-lexer": "^0.3.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.4.2",

--- a/src/lib/token-stream.js
+++ b/src/lib/token-stream.js
@@ -1,0 +1,106 @@
+const { Token, TokenType, SyntaxError, typeToString } = require("twig-lexer");
+
+class TokenStream {
+  /**
+   * @param {Token[]} tokens
+   */
+  constructor(tokens) {
+    this.tokens = tokens;
+    this.current = 0;
+  }
+
+  /**
+   * @return {Token}
+   */
+  next() {
+    this.current++;
+
+    if (this.current >= this.tokens.length) {
+      const token = this.tokens[this.current - 1];
+
+      throw new SyntaxError("Unexpected end of template.", token.getLine(), token.getColumn());
+    }
+
+    return this.tokens[this.current - 1];
+  }
+
+  /**
+   * @param {TokenType} type
+   * @param {String|String[]|Number} value
+   * @return {Token|null}
+   */
+  nextIf(type, value) {
+    if (this.tokens[this.current].test(type, value)) {
+      return this.next();
+    }
+
+    return null;
+  }
+
+  /**
+   * @param {TokenType} type
+   * @param {String|String[]|Number} value
+   * @return {Token}
+   */
+  expect(type, value = null, message = null) {
+    const token = this.tokens[this.current];
+
+    if (!token.test(type, value)) {
+      const line = token.getLine();
+      const column = token.getColumn();
+
+      throw new SyntaxError(`${message ? message + ". " : ""}Unexpected token "${typeToString(token.getType())}" of value "${token.getValue()}" ("${typeToString(type)}" expected${value ? ` with value "${value}"` : ""}).`, line, column);
+    }
+
+    this.next();
+
+    return token;
+  }
+
+  /**
+   * Looks at the next token.
+   *
+   * @param number {number}
+   * @return Token
+   */
+  look(number = 1) {
+    const index = this.current + number;
+
+    if (index >= this.tokens.length) {
+      const token = this.tokens[this.current + number - 1];
+
+      throw new SyntaxError("Unexpected end of template.", token.getLine(), token.getColumn());
+    }
+
+    return this.tokens[index];
+  }
+
+  /**
+   * Tests the active token.
+   *
+   * @param {TokenType} type
+   * @param {String|String[]|Number} value
+   * @return {boolean}
+   */
+  test(type, value = null) {
+    return this.tokens[this.current].test(type, value);
+  }
+
+  /**
+   * Checks if end of stream was reached.
+   *
+   * @return bool
+   */
+  isEOF() {
+    return this.tokens[this.current].getType() === TokenType.EOF;
+  }
+
+  /**
+   * @return Token
+   */
+  getCurrent() {
+    return this.tokens[this.current];
+  }
+};
+
+exports.TokenStream = TokenStream;

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,17 +1,10 @@
-const path = require("path");
-const { TwingEnvironment, TwingSource } = require("twing");
-
-const twing = new TwingEnvironment();
+const { Lexer: TwigLexer } = require("twig-lexer");
 
 function parse(text, parsers, opts) {
-  const filename = opts.filepath ? path.basename(opts.filepath) : null;
-  const filepath = opts.filepath ? opts.filepath : null;
+  const lexer = new TwigLexer();
+  const tokens = lexer.tokenize(text);
 
-  const source = new TwingSource(text, filename, filepath);
-  const tokens = twing.tokenize(source);
-  const nodeModule = twing.parse(tokens);
-
-  return nodeModule;
+  return tokens;
 }
 
 module.exports = parse;

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,9 +1,8 @@
-const { TwingNode, TwingNodeType, TwingNodeExpressionHash, TwingNodeExpressionName, TwingNodeExpressionGetAttr } = require("twing");
+const { Token, TokenType } = require("twig-lexer");
 const { indent, join, line, softline, hardline, concat, group, ifBreak } = require("prettier").doc.builders;
 const util = require("./_util-from-prettier");
 
 // The root, in fact that's not really a node, but it contains references to blocks, macros, ...
-let nodeModule;
 let options;
 
 function indentConcat(docs) {
@@ -14,7 +13,7 @@ function groupConcat(docs) {
   return group(concat(docs));
 }
 
-function printString(rawContent, options) {
+function printString(rawContent) {
   const double = {
     quote: "\"",
     regex: /"/g
@@ -117,111 +116,11 @@ function printEveryNodes(node) {
  * @return {string}
  */
 function genericPrint(path, opts) {
-  /** @type {TwingNode|string} */
-  let node = path.constructor.name === "FastPath" ? path.getValue() : path;
+  /** @type {Token[]} */
+  let tokens = path.getValue();
+  options = opts;
 
-  if (!node) {
-    return "";
-  }
-
-  if (typeof node === "number") {
-    return String(node);
-  }
-
-  if (typeof node === "string") {
-    return printString(node, options || opts);
-  }
-
-  if (node.getType() === TwingNodeType.MODULE) {
-    nodeModule = node;
-    options = opts;
-    node = nodeModule.getNode("body");
-  }
-
-  switch (node.getType()) {
-    case null:
-    case TwingNodeType.BODY: {
-      return printEveryNodes(node);
-    }
-    case TwingNodeType.SET: {
-      const names = Array.from(
-        node
-          .getNode("names")
-          .getNodes()
-          .values()
-      ).map(n => n.getAttribute("name"));
-
-      const values = Array.from(
-        node
-          .getNode("values")
-          .getNodes()
-          .values()
-      ).map(n => genericPrint(n));
-      // const values = printEveryNodes(node.getNode("values"));
-
-      return join(" ", [
-        "{%",
-        node.getNodeTag(),
-        join(", ", names),
-        "=",
-        join(", ", values),
-        "%}",
-        hardline
-      ]);
-    }
-    case TwingNodeType.EXPRESSION_ARRAY: {
-      const isHash = node instanceof TwingNodeExpressionHash;
-      const openDoc = isHash ? concat(["{", ifBreak(" ", line)]) : "[";
-      const closeDoc = isHash ? concat([ifBreak("", line), "}"]) : "]";
-      const items = extractArrayLikeItems(node, isHash);
-
-      return printArrayLike(node, openDoc, items, closeDoc);
-    }
-    case TwingNodeType.EXPRESSION_CONSTANT: {
-      const value = node.getAttribute("value");
-
-      if (typeof value === "string") {
-        return printString(value, options);
-      }
-
-      return String(value);
-    }
-    case TwingNodeType.EXPRESSION_GET_ATTR: {
-      const nodeNode = node.getNode("node");
-      const nodeAttribute = node.getNode("attribute");
-      const nodeArguments = node.getNode("arguments");
-
-      const keyValue = genericPrint(nodeNode);
-      const type = node.getAttribute("type");
-      const value = trimQuotes(genericPrint(nodeAttribute));
-
-      const parameters = nodeArguments.getNodes().size === 0
-        ? ""
-        : printArrayLike(nodeArguments, "(", extractArrayLikeItems(nodeArguments), ")");
-
-      if (type === "array") {
-        return concat([keyValue, "[", value, "]"]);
-      }
-
-      return concat([keyValue, ".", value, parameters]);
-    }
-    case TwingNodeType.EXPRESSION_NAME: {
-      return node.getAttribute("name");
-    }
-    case TwingNodeType.PRINT: {
-      return join(" ", [
-        "{{",
-        printEveryNodes(node),
-        "}}"
-      ]);
-    }
-    case TwingNodeType.TEXT:
-      return node.getAttribute("data");
-    default:
-      throw new Error(`Impossible to prettify a node of type "${node.getType()}". Please open an issue on https://github.com/Kocal/prettier-plugin-twig.`);
-  }
-
-  return "";
+  return 'hello';
 }
 
 module.exports = genericPrint;

--- a/tests/unit/lib/token-stream.js
+++ b/tests/unit/lib/token-stream.js
@@ -1,0 +1,60 @@
+const { Lexer: TwigLexer, TokenType } = require("twig-lexer");
+const { TokenStream } = require("@/lib/token-stream");
+
+describe("TokenStream", () => {
+  const lexer = new TwigLexer();
+
+  test("next()", () => {
+    const tokens = lexer.tokenize("{{foo}}");
+    const stream = new TokenStream(tokens);
+
+    expect(stream.next()).toBe(tokens[0]);
+    expect(stream.next()).toBe(tokens[1]);
+    expect(stream.next()).toBe(tokens[2]);
+
+    expect(() => {
+      stream.next();
+    }).toThrow("Unexpected end of template.");
+  });
+
+  test("nextIf()", () => {
+    const tokens = lexer.tokenize("{{foo}}");
+    const stream = new TokenStream(tokens);
+
+    expect(stream.nextIf(TokenType.VARIABLE_START)).toBe(tokens[0]);
+    expect(stream.nextIf(TokenType.NAME)).toBe(tokens[1]);
+    expect(stream.nextIf(TokenType.VARIABLE_END)).toBe(tokens[2]);
+
+    // returns `null` because normally it's a EOF token
+    expect(stream.nextIf(TokenType.LINE_TRIMMING_MODIFIER)).toBeNull();
+  });
+
+  test("lookup()", () => {
+    const tokens = lexer.tokenize("{{foo}}");
+    const stream = new TokenStream(tokens);
+
+    expect(stream.look(0)).toBe(tokens[0]);
+    expect(stream.look(0)).toBe(stream.getCurrent());
+    expect(stream.look()).toBe(tokens[1]);
+    expect(stream.look(2)).toBe(tokens[2]);
+
+    stream.next();
+    expect(stream.look(0)).toBe(tokens[1]);
+    expect(stream.look(0)).toBe(stream.getCurrent());
+    expect(stream.look()).toBe(tokens[2]);
+    expect(stream.look(2)).toBe(tokens[3]);
+  });
+
+  test("test()", () => {
+    const tokens = lexer.tokenize("{{foo}}");
+    const stream = new TokenStream(tokens);
+
+    expect(stream.test(TokenType.VARIABLE_START)).toBeTruthy();
+
+    stream.next();
+    expect(stream.test(TokenType.NAME)).toBeTruthy();
+
+    stream.next();
+    expect(stream.test(TokenType.VARIABLE_END)).toBeTruthy();
+  })
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,6 +992,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.12.0.tgz#ec5594728811dc2797e42396cfcdf786f2052c12"
   integrity sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg==
 
+"@types/node@^12.0.8":
+  version "12.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.10.tgz#51babf9c7deadd5343620055fc8aff7995c8b031"
+  integrity sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -1221,7 +1226,7 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-arrify@1.0.1, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
@@ -1321,11 +1326,6 @@ babel-preset-jest@^24.3.0:
   dependencies:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.3.0"
-
-babylon@7.0.0-beta.47:
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
-  integrity sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1596,11 +1596,6 @@ caniuse-lite@^1.0.30000951:
   version "1.0.30000954"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000954.tgz#227c2743e40f07c71e6683b6ca9491bfd5755b8e"
   integrity sha512-Wopmc0eVSSG1d9/O4JTn0OmGhUfhEHNkHhoCjUrGSImvHI+2YQWkOI1RRNTUFNSHbSAD8J41jbdZrPP4r32cbQ==
-
-capitalize@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/capitalize/-/capitalize-1.0.0.tgz#dc802c580aee101929020d2ca14b4ca8a0ae44be"
-  integrity sha1-3IAsWAruEBkpAg0soUtMqKCuRL4=
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1980,11 +1975,6 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
-
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -2122,14 +2112,6 @@ define-properties@^1.1.2:
   dependencies:
     object-keys "^1.0.12"
 
-define-property@2.0.2, define-property@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
-  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
-  dependencies:
-    is-descriptor "^1.0.2"
-    isobject "^3.0.1"
-
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -2143,6 +2125,14 @@ define-property@^1.0.0:
   integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
   dependencies:
     is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2355,11 +2345,6 @@ esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-esrever@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/esrever/-/esrever-0.2.0.tgz#96e9d28f4f1b1a76784cd5d490eaae010e7407b8"
-  integrity sha1-lunSj08bGnZ4TNXUkOquAQ50B7g=
 
 estraverse@^4.2.0:
   version "4.2.0"
@@ -2634,15 +2619,6 @@ from2@^2.1.0, from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-fs-extra@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
-  integrity sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^7.0.0:
   version "7.0.1"
@@ -2950,11 +2926,6 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-htmlspecialchars@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/htmlspecialchars/-/htmlspecialchars-1.0.5.tgz#f430f8c1d5f3709be7bebaea696dc04824306a30"
-  integrity sha1-9DD4wdXzcJvnvrrqaW3ASCQwajA=
-
 http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
@@ -2992,7 +2963,7 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.19, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3242,13 +3213,6 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  integrity sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -3288,13 +3252,6 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-integer@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.7.tgz#6bde81aacddf78b659b6629d629cadc51a886d5c"
-  integrity sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=
-  dependencies:
-    is-finite "^1.0.0"
-
 is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
@@ -3311,11 +3268,6 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
-
-is-number@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-5.0.0.tgz#c393bc471e65de1a10a6abcb20efeb12d2b88166"
-  integrity sha512-LmVHHP5dTJwrwZg2Jjqp7K5jpvcnYvYD1LMpvGadMsMv5+WXoDSLBQ0+zmuBJmuZGh2J2K845ygj/YukxUnr4A==
 
 is-obj@^1.0.0:
   version "1.0.1"
@@ -4050,11 +4002,6 @@ leven@^2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
-levenshtein@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/levenshtein/-/levenshtein-1.0.5.tgz#3911737a9cb56da345d008f55782c6f138979ba3"
-  integrity sha1-ORFzepy1baNF0Aj1V4LG8TiXm6M=
-
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -4150,11 +4097,6 @@ lockfile@^1.0.4:
   integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
   dependencies:
     signal-exit "^3.0.2"
-
-locutus@^2.0.9:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/locutus/-/locutus-2.0.10.tgz#f903619466a98a4ab76e8b87a5854b55a743b917"
-  integrity sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ==
 
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
@@ -4259,11 +4201,6 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lower-case@^1.1.1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
-
 lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -4283,11 +4220,6 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
-
-luxon@^1.4.1:
-  version "1.11.4"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.11.4.tgz#c5d8c1f795cee26c162e95a4686632abcec50442"
-  integrity sha512-zTQ1DCShOGHIdNpa56yjDpUCowKDsBqeFVuEG2XBcrAM2udxN0g3N5RTZzbw94OkDiBgECsuDgLNnQTo73yghw==
 
 macos-release@^2.0.0:
   version "2.0.0"
@@ -4442,11 +4374,6 @@ merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
   integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
-
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -4654,13 +4581,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-no-case@^2.2.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
-  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
-  dependencies:
-    lower-case "^1.1.1"
 
 node-emoji@^1.4.1:
   version "1.10.0"
@@ -5064,11 +4984,6 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
-  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
-
 object-keys@^1.0.12:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
@@ -5164,7 +5079,7 @@ os-name@^3.0.0:
     macos-release "^2.0.0"
     windows-release "^3.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -5302,13 +5217,6 @@ pacote@^8.1.6:
     unique-filename "^1.1.0"
     which "^1.3.0"
 
-pad@^2.0.3:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/pad/-/pad-2.2.2.tgz#121a3055be234f27f35a002ee21ccc1364a1f00d"
-  integrity sha512-w5m0/ISM+Jc/xsxNwKzHhOX+KHKYP3tT+UMmZfCgMSLdCccbjMNYx6LtafOql60qI4NYv13ZGAkSiehJj9ttcQ==
-  dependencies:
-    wcwidth "^1.0.1"
-
 parallel-transform@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
@@ -5317,15 +5225,6 @@ parallel-transform@^1.1.0:
     cyclist "~0.2.2"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
-
-parse-function@^5.2.3:
-  version "5.2.11"
-  resolved "https://registry.yarnpkg.com/parse-function/-/parse-function-5.2.11.tgz#89ca2e30b05ecec41e6e12ede647c25839e75036"
-  integrity sha512-2nQChgTKz80awFjQqs93ZzgQPOykT+BXomHUfwMdIben3PT2uohAPot+h5D+PNa0T+odzjuMZUMOoCyJfnej1Q==
-  dependencies:
-    arrify "1.0.1"
-    babylon "7.0.0-beta.47"
-    define-property "2.0.2"
 
 parse-github-url@^1.0.1:
   version "1.0.2"
@@ -5774,11 +5673,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regex-parser@^2.2.8:
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
-  integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
-
 regexp-tree@^0.1.0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.5.tgz#7cd71fca17198d04b4176efd79713f2998009397"
@@ -6027,11 +5921,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-runes@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/runes/-/runes-0.4.3.tgz#32f7738844bc767b65cc68171528e3373c7bb355"
-  integrity sha512-K6p9y4ZyL9wPzA+PMDloNQPfoDGTiFYDvdlXznyGKgD10BJpcAosvATKrExRKOrNLgD8E7Um7WGW0lxsnOuNLg==
-
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -6226,13 +6115,6 @@ smart-buffer@^1.0.13:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"
   integrity sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=
-
-snake-case@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
-  integrity sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=
-  dependencies:
-    no-case "^2.2.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -6689,13 +6571,6 @@ tiny-relative-date@^1.3.0:
   resolved "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"
   integrity sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==
 
-tmp@0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
-
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -6786,36 +6661,12 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twing@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/twing/-/twing-2.2.2.tgz#e56cfda54efdab60d6e6654eda14e2cfaa0d6a3f"
-  integrity sha512-QRF0u6tfPCH2Q05w/AaiZDeVubJo1cWH85HR+Fwfz0kLCbFWmWlPEpMAHaEgvLgDt8pKctJ+XMWtBLA4MKhY5w==
+twig-lexer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/twig-lexer/-/twig-lexer-0.3.0.tgz#b6aa5ce8876519491f42d599688cae8597681bc3"
+  integrity sha512-X6lFlVgKpVoDwngzH20cwqnhhOONUTKjdKM8kEaaMFyLLNnK0EZ6BXXzuASRb0dKfdlzuqmwX/c+v/0YaW0fVw==
   dependencies:
-    camelcase "^4.1.0"
-    capitalize "^1.0.0"
-    crypto-js "^3.1.9-1"
-    esrever "^0.2.0"
-    fs-extra "^5.0.0"
-    htmlspecialchars "^1.0.5"
-    iconv-lite "^0.4.19"
-    is-integer "^1.0.7"
-    is-number "^5.0.0"
-    is-plain-object "^2.0.4"
-    isobject "^3.0.1"
-    levenshtein "^1.0.5"
-    locutus "^2.0.9"
-    luxon "^1.4.1"
-    merge "^1.2.1"
-    object-hash "^1.2.0"
-    pad "^2.0.3"
-    parse-function "^5.2.3"
-    regex-parser "^2.2.8"
-    runes "^0.4.3"
-    snake-case "^2.1.0"
-    source-map "^0.6.1"
-    tmp "0.0.33"
-    utf8-binary-cutter "^0.9.2"
-    var-validator "0.0.3"
+    "@types/node" "^12.0.8"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -6981,13 +6832,6 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-utf8-binary-cutter@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/utf8-binary-cutter/-/utf8-binary-cutter-0.9.2.tgz#c2d28c7f3fd0387e5e162862d32e34090e2b96d9"
-  integrity sha512-lS/2TaA9idsyafus4+WaB+C/AfL3JD85C/sgMJBpplZay1G5SwTQcxmd4jiJLI1VxSJr6a3yuNicBxD+iU2MKQ==
-  dependencies:
-    lodash "^4.17.10"
-
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -7026,11 +6870,6 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-var-validator@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/var-validator/-/var-validator-0.0.3.tgz#8c20155a350373233a542d3e5aed046c90891d70"
-  integrity sha1-jCAVWjUDcyM6VC0+Wu0EbJCJHXA=
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -7054,7 +6893,7 @@ walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
-wcwidth@^1.0.0, wcwidth@^1.0.1:
+wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=


### PR DESCRIPTION
@ericmorand have created the perfect package to lex Twig code: [twig-lexer](https://github.com/NightlyCommit/twig-lexer)

When using Twing, we had some issues about whitespace control modifier (`{%-`, `{{-`, ...) because they were simply removed from tokens and nodes (see ericmorand/twing/issues/321 and ericmorand/twing/pull/326).

But with twig-lexer everything is preserved as tokens, [example](https://runkit.com/embed/ihe7sangdhvs):
![Sélection_916](https://user-images.githubusercontent.com/2103975/60418613-a767f400-9be3-11e9-8824-29fba7af98fb.png)
And so it means that we will be able to print those modifiers back :)

~Actually I will have to rewrite everything since we will use tokens instead of nodes to prettify Twig code.~ In fact not everything, but we have to make sure we are using an AST and not only tokens (even with a token stream), otherwise it will be a pain in the ass.
Since we won't directly use tokens for an AST, we need to find a way to reserve whitespace control modifiers. That can be weird, but I think we can store (on certain types of node) the opening/closing tags with whitespace modifier controls. 🤔

And also use FastPath instead of our own print function because of (https://github.com/prettier/plugin-php/issues/12):
- comment handling around every single node
- access to the parents all the way to the root
- It also allows the multiparser feature to exist 

This PR will close #15, close #4 and close #13 